### PR TITLE
Fixing author name

### DIFF
--- a/Action/Bangi/game.ini
+++ b/Action/Bangi/game.ini
@@ -1,4 +1,4 @@
 title=Bangi
 date=2017-10-31T13:25:29Z
-author=Ignacio Vi�a (igvina)
+author=Ignacio Viña (igvina)
 description=Destroy all the balloons - 45 challenging levels


### PR DESCRIPTION
Ardletics displays the ñ in Ignacio Viña properly, but in Bangi it's a � (which typically shows up as a missing character character, usually a question mark in a diamond).

This fixes that by replacing the � with an ñ copied from Ardletics.