### PR TITLE
Fix Minesweeper source.url

### DIFF
--- a/Puzzle/Minesweeper/source.url
+++ b/Puzzle/Minesweeper/source.url
@@ -1,1 +1,2 @@
-hex=https://github.com/Pharap/Minesweeper/releases/download/v2.0.0/Minesweeper.EN-GB.hex
+[InternetShortcut]
+URL=https://github.com/Pharap/Minesweeper/tree/v2.0.0


### PR DESCRIPTION
Fixes `source.url`. Somehow this ended up with a link to the `hex` file instead.