### PR TITLE
Fix Kemono Patrol website url

### DIFF
--- a/Shooter/Kemono Patrol/website.url
+++ b/Shooter/Kemono Patrol/website.url
@@ -1,2 +1,2 @@
 [InternetShortcut]
-URL=https://twitter.com/renibrain/status/849182019628040192
+URL=https://twitter.com/metalidol/status/843874920052346881


### PR DESCRIPTION
I don't know why, but this link seems to be pointing to the wrong thing.
This commit points it back to the correct link, as specified by the following forum thread:
https://community.arduboy.com/t/arduboy-antena-only-japan-website/3478