### PR TITLE
Fix OYGD website url

### DIFF
--- a/Arcade/Oh, You're Gunna Die/website.url
+++ b/Arcade/Oh, You're Gunna Die/website.url
@@ -1,2 +1,2 @@
 [InternetShortcut]
-URL=https://www.google.no/search?q=URL%3D&oq=URL%3D&aqs=chrome..69i57.207j0j4&sourceid=chrome&ie=UTF-8
+URL=https://community.arduboy.com/t/o-y-g-d-kinda-like-bomberman-i-guess/2462


### PR DESCRIPTION
Another case of an incorrect url.
I'm guessing this was a case of `ctrl+c` failing.
This commit fixes the link.